### PR TITLE
feat: 드래그드랍 기능 설정 side effects Fix

### DIFF
--- a/src/components/TodoList/index.tsx
+++ b/src/components/TodoList/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Plus from '../../assets/svg/Plus'
 import XMark from '../../assets/svg/XMark'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
@@ -13,14 +13,54 @@ export const TodoList = ({ todos = [], onChange }: Props) => {
   const [newTodoText, setNewTodoText] = useState('')
   const newTodoInputRef = useRef<HTMLInputElement>(null)
   const [showNewTodoInput, setShowNewTodoInput] = useState(false)
-
   const [parent] = useAutoAnimate()
+
+  let hasFocus = document.activeElement
+  if (!hasFocus || hasFocus == document.body) hasFocus = null
+  else if (document.querySelector) hasFocus = document.querySelector(':focus')
 
   const addTodo = (value: string) => {
     if (!value.trim()) return
     setNewTodoText('')
     onChange([{ text: value, id: Date.now(), completed: false }, ...todos])
     newTodoInputRef.current?.focus()
+  }
+
+  // 타이머 영향으로 계속 리렌더링 되고 있어 이 부분이라도 메모이제이션을 해줌
+  const memoizedTodos = () => {
+    return todos.map((todo, i) => (
+      <li key={todo.id} className="bg-white flex justify-between items-center p-3 mb-2 rounded-md cursor-grab">
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            checked={todo.completed}
+            onChange={e => {
+              onChange(
+                todos.map((todo, j) => {
+                  if (i === j) {
+                    return {
+                      ...todo,
+                      completed: e.target.checked,
+                    }
+                  }
+                  return todo
+                }),
+              )
+            }}
+            className="ignore-dnd checkbox checkbox-accent mr-2 focus:outline-none focus:ring-lime-300 focus:border-lime-300"
+          />
+          {todo.text}
+        </div>
+        <button
+          className="ignore-dnd"
+          onClick={e => {
+            e.preventDefault()
+            onChange(todos.filter((_, j) => i !== j))
+          }}>
+          <XMark />
+        </button>
+      </li>
+    ))
   }
 
   return (
@@ -63,42 +103,13 @@ export const TodoList = ({ todos = [], onChange }: Props) => {
             </button>
           </div>
         )}
-        <ul ref={parent}>
-          <ReactSortable list={todos} setList={onChange} animation={200} swap>
-            {todos.map((todo, i) => (
-              <li key={todo.id} className="bg-white flex justify-between items-center p-3 mb-2 rounded-md cursor-grab">
-                <div className="flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={todo.completed}
-                    onChange={e => {
-                      onChange(
-                        todos.map((todo, j) => {
-                          if (i === j) {
-                            return {
-                              ...todo,
-                              completed: e.target.checked,
-                            }
-                          }
-                          return todo
-                        }),
-                      )
-                    }}
-                    className="checkbox checkbox-accent mr-2 focus:outline-none focus:ring-lime-300 focus:border-lime-300"
-                  />
-                  {todo.text}
-                </div>
-                <button
-                  onClick={e => {
-                    e.preventDefault()
-                    onChange(todos.filter((_, j) => i !== j))
-                  }}>
-                  <XMark />
-                </button>
-              </li>
-            ))}
+        {hasFocus ? (
+          <ul ref={parent}>{memoizedTodos()}</ul>
+        ) : (
+          <ReactSortable list={todos} setList={onChange} filter=".ignore-dnd" animation={200}>
+            {memoizedTodos()}
           </ReactSortable>
-        </ul>
+        )}
       </div>
     </>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,6 +12,8 @@ export function Home({}: Props) {
     { id: 4, text: '운동하기4', completed: true },
     { id: 5, text: '운동하기5', completed: true },
   ])
+  // 가능하면 ctrl+z를 누르면 이전 상태로 돌아가게 하고 싶다.
+  // const [todosHistory, setTodosHistory] = useState([])
 
   const { minutes, seconds } = useCountdown({
     minutes: 30,


### PR DESCRIPTION
이전에 추가한 Todo 아이템들 드래그 앤 드랍으로 정렬 가능한 기능이 사이드 이펙트를 만들어 수정
- Todo 아이템 전체 영역이 드래그 앤 드랍 영역이 되어버려 삭제 기능과 체크박스 토글 기능이 제대로 동작하지 않아서, filter prop 에 클래스 셀렉터를 넣어 원하는대로 동작하도록 수정
- 할 일 추가 때 애니메이션도 되살리기 위해 상황에 따라 드래그앤드랍 기능을 키고 끄도록 함(focus 된 input 이 있으면 기능 끄기)