### PR TITLE
REFACT: 모달 사용성 개선

### DIFF
--- a/src/api/countDownTimer.ts
+++ b/src/api/countDownTimer.ts
@@ -4,7 +4,6 @@ import { User } from '../types'
 export const postNewGroup = async (timerInfo: FormData) => {
   try {
     const response = await api.post(`/timers`, timerInfo)
-    console.log(response)
     return response.data
   } catch (e) {
     console.log(e)

--- a/src/components/InputBox/index.tsx
+++ b/src/components/InputBox/index.tsx
@@ -254,7 +254,9 @@ InputBox.StartTimeSet = ({ InputBoxName, startTime, setStartTime }: StartTimeSet
             <input
               className="focus-visible:none input h-1/2 w-full rounded-[10px] border-grey-800 bg-grey-900 text-display6 focus:outline-none"
               value={`${startTime.getHours() < 12 ? '오전' : '오후'} ${
-                startTime.getHours() < 12
+                startTime.getHours() === (0 || 12)
+                  ? 12
+                  : startTime.getHours() < 12
                   ? `${String(startTime.getHours()).padStart(2, '0')}`
                   : `${String(startTime.getHours() - 12).padStart(2, '0')}`
               } : ${String(startTime.getMinutes()).padStart(2, '0')}`}

--- a/src/components/ModalSelectElement/index.tsx
+++ b/src/components/ModalSelectElement/index.tsx
@@ -21,10 +21,11 @@ const ModalSelectElement = ({ content, data, setData, isMinute = false }: ModalS
   useEffect(() => {
     if (typeof data === 'boolean') {
       contentData = content !== '오전'
+      setSelect(data === contentData)
     } else {
       contentData = content
+      setSelect((contentData === 12 && data === 0) || data === contentData)
     }
-    setSelect(data === contentData)
   }, [data])
 
   return (
@@ -35,7 +36,7 @@ const ModalSelectElement = ({ content, data, setData, isMinute = false }: ModalS
       onClick={() => {
         dataHandling()
       }}>
-      <label className={'w-full'}>{isMinute ? String(content).padStart(2, '0') : content}</label>
+      <label className="w-full">{isMinute ? String(content).padStart(2, '0') : content}</label>
     </div>
   )
 }
@@ -47,8 +48,12 @@ interface CalendarElementProps extends ModalSelectElementProps {
 // eslint-disable-next-line react/display-name
 ModalSelectElement.CalenderElement = ({ content, data, setData, timeInfo }: CalendarElementProps) => {
   const [select, setSelect] = useState(false)
+  const [isPrev, setIsPrev] = useState(false)
 
   const dataHandling = () => {
+    if (isPrev) {
+      return null
+    }
     return setData(new Date(timeInfo[0], timeInfo[1], timeInfo[2], data.getHours(), data.getMinutes()))
   }
 
@@ -56,15 +61,22 @@ ModalSelectElement.CalenderElement = ({ content, data, setData, timeInfo }: Cale
     const nowData = new Date(data.getFullYear(), data.getMonth(), data.getDate(), data.getHours(), data.getMinutes())
     const elementData = new Date(timeInfo[0], timeInfo[1], timeInfo[2], data.getHours(), data.getMinutes())
     setSelect(nowData.valueOf() === elementData.valueOf())
+    const nowDate = new Date()
+    nowDate.setHours(0, 0, 0, 0)
+    setIsPrev(elementData < nowDate)
   }, [data])
 
   return content !== ' ' ? (
     <div
       className={`${
-        select ? 'bg-primary text-white' : 'bg-grey-900 text-grey-600'
+        isPrev
+          ? 'cursor-default bg-grey-1000 text-grey-800'
+          : select
+          ? 'bg-primary text-white'
+          : 'bg-grey-900 text-grey-600'
       } p-autos flex h-full w-full items-center rounded-[0.625rem] text-center`}
       onClick={dataHandling}>
-      <label className={'w-full'}>{content}</label>
+      <label className={`w-full ${isPrev ? `cursor-default` : `cursor-pointer`}`}>{content}</label>
     </div>
   ) : (
     <div></div>

--- a/src/components/TimerMakeModal/index.tsx
+++ b/src/components/TimerMakeModal/index.tsx
@@ -328,13 +328,13 @@ TimerMakeModal.ErrorModal = ({ closePortal }: { closePortal: any }) => {
   return (
     <div className="fixed right-1/2 bottom-1/2 h-[190px] w-[388px] translate-x-1/2 translate-y-1/2 rounded-2xl bg-grey-850 px-[22px] pb-4.5 pt-[25px] text-left">
       <div className="mb-4">
-        <span className="text-[22px] font-bold text-grey-200">시간을 확인해주세요!</span>
+        <span className="text-[22px] font-bold text-grey-200">설정된 시간이 올바르지 않아요!</span>
       </div>
       <div className="mb-5.5">
-        <span>설정된 시간이 올바르지 않아요</span>
+        <span>시간을 확인해주세요</span>
       </div>
       <div className="flex text-title2 font-semibold text-white">
-        <button className="mr-[10px] h-[60px] w-full rounded-[10px] bg-grey-800" onClick={handleClickEvent}>
+        <button className="mr-[10px] h-[60px] w-full rounded-[10px] bg-primary" onClick={handleClickEvent}>
           닫기
         </button>
       </div>

--- a/src/components/TimerMakeModal/index.tsx
+++ b/src/components/TimerMakeModal/index.tsx
@@ -190,24 +190,25 @@ interface StartTimePickerProps {
 
 // eslint-disable-next-line react/display-name
 TimerMakeModal.StartTimePicker = ({ startTime, setStartTime, modalClose }: StartTimePickerProps) => {
-  const [dayTime, setDayTime] = useState(startTime.getHours() > 12)
+  const [dayTime, setDayTime] = useState(startTime.getHours() >= 12)
   const [hour, setHour] = useState(startTime.getHours() > 12 ? startTime.getHours() - 12 : startTime.getHours())
   const [minute, setMinute] = useState(startTime.getMinutes())
 
   const times = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
   const minutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]
 
+  const handleTime = (hour: number) => {
+    if (!dayTime && hour === 12) {
+      return 0
+    } else if (dayTime && hour == 12) {
+      return 12
+    } else {
+      return dayTime ? hour + 12 : hour
+    }
+  }
   const handleOnClick = () => {
-    setStartTime(
-      new Date(
-        startTime.getFullYear(),
-        startTime.getMonth(),
-        startTime.getDate(),
-        dayTime ? hour + 12 : hour,
-        minute,
-        0,
-      ),
-    )
+    const editHour = handleTime(hour)
+    setStartTime(new Date(startTime.getFullYear(), startTime.getMonth(), startTime.getDate(), editHour, minute, 0))
 
     modalClose()
   }
@@ -312,6 +313,29 @@ TimerMakeModal.CompleteModal = ({ closePortal, invitationCode }: { closePortal: 
             <img className="mr-[4px]" src={LinkShareIcon} alt="링크 공유하기 버튼" />
             <span>코드 공유</span>
           </div>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// eslint-disable-next-line react/display-name
+TimerMakeModal.ErrorModal = ({ closePortal }: { closePortal: any }) => {
+  const handleClickEvent = () => {
+    closePortal()
+  }
+
+  return (
+    <div className="fixed right-1/2 bottom-1/2 h-[190px] w-[388px] translate-x-1/2 translate-y-1/2 rounded-2xl bg-grey-850 px-[22px] pb-4.5 pt-[25px] text-left">
+      <div className="mb-4">
+        <span className="text-[22px] font-bold text-grey-200">시간을 확인해주세요!</span>
+      </div>
+      <div className="mb-5.5">
+        <span>설정된 시간이 올바르지 않아요</span>
+      </div>
+      <div className="flex text-title2 font-semibold text-white">
+        <button className="mr-[10px] h-[60px] w-full rounded-[10px] bg-grey-800" onClick={handleClickEvent}>
+          닫기
         </button>
       </div>
     </div>

--- a/src/pages/CountDownNew.tsx
+++ b/src/pages/CountDownNew.tsx
@@ -7,14 +7,12 @@ import { Timer } from '../types'
 import { formatISO } from 'date-fns'
 import ModalPortal from '../components/ModalPortal'
 import { postNewGroup } from '../api/countDownTimer'
-import { useRecoilValue } from 'recoil'
-import { userAtom } from '../recoil/atoms'
-import { Navigate } from 'react-router'
 
 export function CountDownNew() {
   const [startTime, setStartTime] = useState(new Date())
   const [modalVisible, setModalVisible] = useState(false)
   const [invitationCode, setInvitationCode] = useState('')
+  const [isError, setIsError] = useState(false)
 
   const modalOpen = () => {
     return setModalVisible(true)
@@ -34,9 +32,15 @@ export function CountDownNew() {
     },
   })
   const onSubmit = async (data: any) => {
-    const response = await postNewGroup(data)
-    setInvitationCode(response.invitationCode)
-    modalOpen()
+    if (startTime < new Date()) {
+      setIsError(true)
+      modalOpen()
+    } else {
+      setIsError(false)
+      const response = await postNewGroup(data)
+      setInvitationCode(response.invitationCode)
+      modalOpen()
+    }
   }
   return (
     <div className="h-full bg-[#0F1214] text-center">
@@ -62,7 +66,11 @@ export function CountDownNew() {
           </FormProvider>
           {modalVisible && (
             <ModalPortal closePortal={modalClose} isOpened={modalVisible}>
-              <TimerMakeModal.CompleteModal closePortal={modalClose} invitationCode={invitationCode} />
+              {isError ? (
+                <TimerMakeModal.ErrorModal closePortal={modalClose} />
+              ) : (
+                <TimerMakeModal.CompleteModal closePortal={modalClose} invitationCode={invitationCode} />
+              )}
             </ModalPortal>
           )}
         </div>


### PR DESCRIPTION
## 작업 내용
이전에 캘린더 모달에서 이전날짜 선택이 가능했습니다.
이를 선택 불가능하게 바꿨습니다.

시간 선택 모달의 경우, 세팅 value가 5분 단위로 끊어져 가장 가까운 5분 단위의 시간으로 이동하는데,
폼을 작성하는 과정에서 시간이 흐를 수도 있음을 고려하여
모달로 잘못된 시간이 설정되었음을 표시하는 모달을 생성하여 띄웠습니다.
